### PR TITLE
allow checklists to render properly in vignette

### DIFF
--- a/vignettes/release-checklists.qmd
+++ b/vignettes/release-checklists.qmd
@@ -61,7 +61,10 @@ The release process for CRAN releases requires extra time and attention. A good 
     - [ ] Rebuild `README.md`.
  - [ ] Use `devtools::check(remote = TRUE, manual = TRUE)` to check the package locally.
  - [ ] Use `devtools::check_win_devel()` to check the package with the devel version of R on <https://win-builder.r-project.org/>.
- - Record the results of checks and respond concisely to any NOTEs not addressed in the `cran-comments.md` file. The contents of this file are included with package submission to CRAN. See more about [using `cran-comments.md` to communicate with CRAN](https://r-pkgs.org/release.html#sec-release-cran-comments). If the package does not have a `cran-comments.md` file, you can create one using `usethis::use_cran_comments()`.
+ - [ ] Record the results of checks and respond concisely to any NOTEs not addressed in the `cran-comments.md` file. 
+       The contents of this file are included with package submission to CRAN. 
+       See more about [using `cran-comments.md` to communicate with CRAN](https://r-pkgs.org/release.html#sec-release-cran-comments). 
+       If the package does not have a `cran-comments.md` file, you can create one using `usethis::use_cran_comments()`.
  - [ ] Make sure all your changes are committed and pushed to your release branch.
  - [ ] Remove the `Remotes:` items in the DESCRIPTION with the [`desc`](https://r-lib.github.io/desc) package:
    ```r
@@ -82,9 +85,9 @@ development
 
  - [ ] Create new branch from `main` called `post-release-X.Y.Z`
  - [ ] Set project to development version by:
-        * Adding `.9000` to the version number (to indicate in development version)
-        * Adding a new heading to `NEWS.md` or `changelog.md`: `## <package name> (development)`.
-        For R packages you can do both with `usethis::use_dev_version()`.
+   - [ ] Adding `.9000` to the version number (to indicate in development version)
+   - [ ] Adding a new heading to `NEWS.md` or `changelog.md`: `## <package name> (development)`.
+         For R packages you can do both with `usethis::use_dev_version()`.
  - [ ] commit, push changes, create a pull request
  - [ ] merge (with approval)
 


### PR DESCRIPTION
This fixes the markdown so that the checklists render properly in the vignette.

I didn't bump the version because this is a minor typo fix and should be
available on the main site, but if we want to demonstrate the full release
process, I'm also happy to do that. 


