### PR TITLE
release process vignette: move approval to come before CRAN submission

### DIFF
--- a/vignettes/release-checklists.qmd
+++ b/vignettes/release-checklists.qmd
@@ -22,8 +22,11 @@ Parts of this document is adapted for The Hubverse from [The Carpentries Develop
  - [ ] (For R packages) Check that all new authors/contributors are accounted for in the `DESCRIPTION`
  - [ ] Proofread the `NEWS.md` or  `changelog.md` and update the version number
  - [ ] Commit, push changes, and create a draft pull request (tests will run against the released versions of the dependencies)
- - [ ] (For R packages) If package is on CRAN, [follow the steps to release to CRAN](#release-to-cran). A good place to start would be to open a template release issue using `usethis::use_release_issue()` and follow the instructions. 
- - [ ] Get a review from another member of the Hubverse dev team and merge on approval
+ - [ ] Get a review from another member of the Hubverse dev team
+    - [ ] (For R packages) If package is on CRAN, [follow the steps to release to CRAN](#release-to-cran). 
+      Only merge when you get an email that says "on it's way to CRAN".
+      A good place to start would be to open a template release issue using `usethis::use_release_issue()` and follow the instructions. 
+    - [ ] Merge on approval/CRAN acceptance
  - [ ] Checkout the `main` branch and make sure to pull the merged in changes.
  - [ ] Add new tag (annotated (`-a`) or signed (`-s`) preferred) with the name "<package> X.Y.Z" and push
       

--- a/vignettes/release-process.qmd
+++ b/vignettes/release-process.qmd
@@ -236,7 +236,8 @@ guidelines](https://github.com/orgs/hubverse-org/discussions/29).
 This release process assumes that we have accumulated bugfixes and/or features
 in the `main` branch, which we are ready to release. If you have a bug that
 needs to be patched _immediately_ and you have new features in the main branch
-that are not yet released, then you should [create a hotfix](hotfixes) instead.
+that are not yet ready to be released, then you should [create a
+hotfix](hotfixes) instead.
 
 ### Releases
 


### PR DESCRIPTION
I noticed that the order of the checklist was slightly off and it suggested to submit to CRAN _before_ getting a review. It's a minor point since a release workflow is mostly a formality, but it can help catch things that the CRAN maintainers might get angry about beforehand. 
