### PR TITLE
update year snapshot

### DIFF
--- a/tests/testthat/_snaps/create_hubdev_pkg.md
+++ b/tests/testthat/_snaps/create_hubdev_pkg.md
@@ -103,6 +103,6 @@
     Code
       readLines(fs::path(pkg_path, "LICENSE"))
     Output
-      [1] "YEAR: 2024"                                                      
+      [1] "YEAR: 2025"                                                      
       [2] "COPYRIGHT HOLDER: Consortium of Infectious Disease Modeling Hubs"
 


### PR DESCRIPTION
With the new year, the snapshot tests fail because the copyright year has been bumped. 

This is a quick fix that bumps the copyright year. 