### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # hubDevs 0.1.1.9000
 
 * Remove Hubverse release process overview vignettes (that information has moved
-  to the [Hubverse documentation](https://hubverse.io/en/latest/developer/)).
+  to the [Hubverse documentation](https://docs.hubverse.io/en/latest/developer/)).
 
 # hubDevs 0.1.1
 

--- a/R/append_hubdev_readme_footer.R
+++ b/R/append_hubdev_readme_footer.R
@@ -2,7 +2,7 @@
 #'
 #' @inheritParams create_hubdev_pkg
 #' @export
-append_hubdev_readme_footer <- function(hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html") { # nolint
+append_hubdev_readme_footer <- function(hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html") { # nolint
   data <- list(
     pkgname = get_pkgname(),
     hubdocs_contribute_url = hubdocs_contribute_url

--- a/R/community.R
+++ b/R/community.R
@@ -11,7 +11,7 @@
 #' @describeIn use_hubdev_community Create hubverse `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md` files.
 use_hubdev_community <- function(
     organisation = "hubverse-org",
-    hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html") {
+    hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html") {
   use_hubdev_coc()
   use_hubdev_contributing(
     organisation = organisation,
@@ -38,7 +38,7 @@ use_hubdev_coc <- function() {
 #' @describeIn use_hubdev_community Create hubverse `CONTRIBUTING.md` file.
 use_hubdev_contributing <- function(
     organisation = "hubverse-org",
-    hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html") {
+    hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html") {
   usethis::use_directory(".github", ignore = TRUE)
   usethis::use_git_ignore("*.html", directory = ".github")
 

--- a/inst/templates/package-README
+++ b/inst/templates/package-README
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 
 The goal of {{{ pkgname }}} is to ...
 
-This package is part of the [hubverse](https://hubverse.io/en/latest/) ecosystem, which aims to provide a set of tools for infectious disease modeling hubs to share and collaborate on their work.
+This package is part of the [hubverse](https://hubverse.io) ecosystem, which aims to provide a set of tools for infectious disease modeling hubs to share and collaborate on their work.
 
 ## Documentation
 

--- a/vignettes/release-process.qmd
+++ b/vignettes/release-process.qmd
@@ -11,8 +11,8 @@ vignette: >
 Information about releasing Hubverse packages has moved to the
 Hubverse documentation:
 
-- [Release process overview](https://hubverse.io/en/latest/developer/release-process.html)
-- [Releasing hotfixes](https://hubverse.io/en/latest/developer/hotfix.html)
-- [Python-specific release details and checklists](https://hubverse.io/en/latest/developer/python.html)
+- [Release process overview](https://docs.hubverse.io/en/latest/developer/release-process.html)
+- [Releasing hotfixes](https://docs.hubverse.io/en/latest/developer/hotfix.html)
+- [Python-specific release details and checklists](https://docs.hubverse.io/en/latest/developer/python.html)
 
 **An R-specific release checklist is here: `vignette("release-checklists", package = "hubDevs")`.**


### PR DESCRIPTION
This PR updates legacy hubverse.io links to docs.hubverse.io.