### PR TITLE
Update links to docs.hubverse.io

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -38,11 +38,11 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
+Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
 
-Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
+Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
 
-The Code of Conduct Committee will use the [Enforcement Manual](https://hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
+The Code of Conduct Committee will use the [Enforcement Manual](https://docs.hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
 
 
 ## Scope

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 This outlines how to propose a change to `hubDevs`.
 For more general info about contributing to this, and other hubverse packages, please see the
-[**hubverse contributing guide**](https://hubverse.io/en/latest/overview/contribute.html).
+[**hubverse contributing guide**](https://docs.hubverse.io/en/latest/overview/contribute.html).
 
 You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the *source* file.
 This generally means you'll need to edit [roxygen2 comments](https://roxygen2.r-lib.org/articles/roxygen2.html) in an `.R`, not a `.Rd` file.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # hubDevs 0.1.1.9000
 
 * Remove Hubverse release process overview vignettes (that information has moved
-  to the [Hubverse documentation](https://hubverse.io/en/latest/developer/)).
+  to the [Hubverse documentation](https://docs.hubverse.io/en/latest/developer/)).
 
 # hubDevs 0.1.1
 

--- a/R/append_hubdev_readme_footer.R
+++ b/R/append_hubdev_readme_footer.R
@@ -2,7 +2,7 @@
 #'
 #' @inheritParams create_hubdev_pkg
 #' @export
-append_hubdev_readme_footer <- function(hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html") { # nolint
+append_hubdev_readme_footer <- function(hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html") { # nolint
   data <- list(
     pkgname = get_pkgname(),
     hubdocs_contribute_url = hubdocs_contribute_url

--- a/R/community.R
+++ b/R/community.R
@@ -11,7 +11,7 @@
 #' @describeIn use_hubdev_community Create hubverse `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md` files.
 use_hubdev_community <- function(
     organisation = "hubverse-org",
-    hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html") {
+    hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html") {
   use_hubdev_coc()
   use_hubdev_contributing(
     organisation = organisation,
@@ -38,7 +38,7 @@ use_hubdev_coc <- function() {
 #' @describeIn use_hubdev_community Create hubverse `CONTRIBUTING.md` file.
 use_hubdev_contributing <- function(
     organisation = "hubverse-org",
-    hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html") {
+    hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html") {
   usethis::use_directory(".github", ignore = TRUE)
   usethis::use_git_ignore("*.html", directory = ".github")
 

--- a/R/create_hubdev_pkg.R
+++ b/R/create_hubdev_pkg.R
@@ -14,7 +14,7 @@ create_hubdev_pkg <- function(
     path, fields = list(),
     copyright_holder = "Consortium of Infectious Disease Modeling Hubs",
     organisation = "hubverse-org",
-    hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html") {
+    hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html") {
   path <- usethis::create_package(path,
     fields = fields,
     rstudio = TRUE, open = FALSE

--- a/R/use_hubdev_readme.R
+++ b/R/use_hubdev_readme.R
@@ -4,7 +4,7 @@
 #' @export
 use_hubdev_readme <- function(
     organisation = "hubverse-org",
-    hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html") {
+    hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html") {
   rlang::check_installed("rmarkdown")
 
   data <- list(

--- a/README.Rmd
+++ b/README.Rmd
@@ -135,6 +135,6 @@ Please note that the hubDevs package is released with a [Contributor Code of Con
 ## Contributing
 
 Interested in contributing back to the open-source Hubverse project?
-Learn more about how to [get involved in the Hubverse Community](https://hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubDevs package](.github/CONTRIBUTING.md).
+Learn more about how to [get involved in the Hubverse Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the hubDevs package](.github/CONTRIBUTING.md).
 
 

--- a/README.md
+++ b/README.md
@@ -243,5 +243,5 @@ project, you agree to abide by its terms.
 
 Interested in contributing back to the open-source Hubverse project?
 Learn more about how to [get involved in the Hubverse
-Community](https://hubverse.io/en/latest/overview/contribute.html) or
+Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or
 [how to contribute to the hubDevs package](.github/CONTRIBUTING.md).

--- a/inst/templates/CODE_OF_CONDUCT.md
+++ b/inst/templates/CODE_OF_CONDUCT.md
@@ -38,11 +38,11 @@ Examples of unacceptable behavior include:
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
+Community leaders are responsible for clarifying our standards of acceptable behavior. Enforcement is the responsibility of the [Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html), who will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful. 
 
-Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
+Instances of abusive, harassing, or otherwise unacceptable behavior [may be reported to any member of the Code of Conduct Committee](https://docs.hubverse.io/en/latest/coc/committee.html). All complaints will be reviewed and investigated promptly and fairly. 
 
-The Code of Conduct Committee will use the [Enforcement Manual](https://hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
+The Code of Conduct Committee will use the [Enforcement Manual](https://docs.hubverse.io/en/latest/coc/enforcement-manual.html) in determining the consequences for any action they deem in violation of this Code of Conduct. All community leaders and Code of Conduct Committee members are obligated to respect the privacy and security of the reporter of any incident.
 
 
 ## Scope

--- a/inst/templates/package-README
+++ b/inst/templates/package-README
@@ -20,7 +20,7 @@ knitr::opts_chunk$set(
 
 The goal of {{{ pkgname }}} is to ...
 
-This package is part of the [hubverse](https://hubverse.io/en/latest/) ecosystem, which aims to provide a set of tools for infectious disease modeling hubs to share and collaborate on their work.
+This package is part of the [hubverse](https://hubverse.io) ecosystem, which aims to provide a set of tools for infectious disease modeling hubs to share and collaborate on their work.
 
 ## Documentation
 

--- a/man/append_hubdev_readme_footer.Rd
+++ b/man/append_hubdev_readme_footer.Rd
@@ -5,7 +5,7 @@
 \title{Append the standard hubverse footer to a README.Rmd}
 \usage{
 append_hubdev_readme_footer(
-  hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html"
+  hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html"
 )
 }
 \arguments{

--- a/man/create_hubdev_pkg.Rd
+++ b/man/create_hubdev_pkg.Rd
@@ -9,7 +9,7 @@ create_hubdev_pkg(
   fields = list(),
   copyright_holder = "Consortium of Infectious Disease Modeling Hubs",
   organisation = "hubverse-org",
-  hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html"
+  hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html"
 )
 }
 \arguments{

--- a/man/use_hubdev_community.Rd
+++ b/man/use_hubdev_community.Rd
@@ -8,14 +8,14 @@
 \usage{
 use_hubdev_community(
   organisation = "hubverse-org",
-  hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html"
+  hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html"
 )
 
 use_hubdev_coc()
 
 use_hubdev_contributing(
   organisation = "hubverse-org",
-  hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html"
+  hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html"
 )
 }
 \arguments{

--- a/man/use_hubdev_readme.Rd
+++ b/man/use_hubdev_readme.Rd
@@ -6,7 +6,7 @@
 \usage{
 use_hubdev_readme(
   organisation = "hubverse-org",
-  hubdocs_contribute_url = "https://hubverse.io/en/latest/overview/contribute.html"
+  hubdocs_contribute_url = "https://docs.hubverse.io/en/latest/overview/contribute.html"
 )
 }
 \arguments{

--- a/tests/testthat/_snaps/create_hubdev_pkg.md
+++ b/tests/testthat/_snaps/create_hubdev_pkg.md
@@ -47,7 +47,7 @@
       [22] ""                                                                                                                                                                                                   
       [23] "The goal of testPkg is to ..."                                                                                                                                                                      
       [24] ""                                                                                                                                                                                                   
-      [25] "This package is part of the [hubverse](https://hubverse.io/en/latest/) ecosystem, which aims to provide a set of tools for infectious disease modeling hubs to share and collaborate on their work."
+      [25] "This package is part of the [hubverse](https://hubverse.io) ecosystem, which aims to provide a set of tools for infectious disease modeling hubs to share and collaborate on their work."
       [26] ""                                                                                                                                                                                                   
       [27] "## Documentation"                                                                                                                                                                                   
       [28] ""                                                                                                                                                                                                   
@@ -91,7 +91,7 @@
       [66] "## Contributing"                                                                                                                                                                                    
       [67] ""                                                                                                                                                                                                   
       [68] "Interested in contributing back to the open-source Hubverse project?"                                                                                                                               
-      [69] "Learn more about how to [get involved in the Hubverse Community](https://hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the testPkg package](.github/CONTRIBUTING.md)."   
+      [69] "Learn more about how to [get involved in the Hubverse Community](https://docs.hubverse.io/en/latest/overview/contribute.html) or [how to contribute to the testPkg package](.github/CONTRIBUTING.md)."   
 
 ---
 

--- a/vignettes/release-checklists.qmd
+++ b/vignettes/release-checklists.qmd
@@ -128,7 +128,7 @@ Caveats:
 
  1. You should not change the development version number, **unless
     there are important feature changes that are required by an upstream
-    package** (see [more about the development version number](https://hubverse.io/en/latest/developer/release-process.html#versioning)).
+    package** (see [more about the development version number](https://docs.hubverse.io/en/latest/developer/release-process.html#versioning)).
  2. If introducing **breaking changes**, you must not merge into `main` until
     these changes have been tested and communicated with the community.
 
@@ -136,7 +136,7 @@ Caveats:
 
 A hotfix is a bug fix that is independent from in-development features and needs
 to be deployed within a day. Refer to the Hubverse documentation for
-[details about hotfixes](https://hubverse.io/en/latest/developer/hotfix.html).
+[details about hotfixes](https://docs.hubverse.io/en/latest/developer/hotfix.html).
 
 To patch and release a hotfix, follow this protocol:
 
@@ -153,7 +153,7 @@ To patch and release a hotfix, follow this protocol:
    (znk/hotfix/143)$ git push -u origin znk/hotfix/143 # push the hotfix
    ```
  - [ ] Create a pull request, get a review from another hubverse developer, and confirm that checks pass against the released versions of the packages **(Do not merge yet)**
- - [ ] Update the NEWS and bump the [patch version](https://hubverse.io/en/latest/developer/release-process.html#patch) in the DESCRIPTION
+ - [ ] Update the NEWS and bump the [patch version](https://docs.hubverse.io/en/latest/developer/release-process.html#patch) in the DESCRIPTION
  - [ ] Release from the hotfix branch
    ```sh
    (znk/hotfix/143)$ git commit -m 'bump version to 0.14.1'

--- a/vignettes/release-process.qmd
+++ b/vignettes/release-process.qmd
@@ -11,8 +11,8 @@ vignette: >
 Information about releasing Hubverse packages has moved to the
 Hubverse documentation:
 
-- [Release process overview](https://hubverse.io/en/latest/developer/release-process.html)
-- [Releasing hotfixes](https://hubverse.io/en/latest/developer/hotfix.html)
-- [Python-specific release details and checklists](https://hubverse.io/en/latest/developer/python.html)
+- [Release process overview](https://docs.hubverse.io/en/latest/developer/release-process.html)
+- [Releasing hotfixes](https://docs.hubverse.io/en/latest/developer/hotfix.html)
+- [Python-specific release details and checklists](https://docs.hubverse.io/en/latest/developer/python.html)
 
 **An R-specific release checklist is here: `vignette("release-checklists", package = "hubDevs")`.**


### PR DESCRIPTION
This PR updates `hubverse.io` URLs to point to `docs.hubverse.io`.

📝 Multiple commits — feel free to **Squash and Merge** to keep history clean.